### PR TITLE
Process citations in .md output files through Pandoc

### DIFF
--- a/R/build_one.R
+++ b/R/build_one.R
@@ -15,4 +15,7 @@ local({
   options(digits = 4)
   knitr::opts_knit$set(width = 70)
   knitr::knit(a[1], a[2], quiet = TRUE, encoding = 'UTF-8', envir = .GlobalEnv)
+  # process citations through Pandoc
+  x = blogdown:::process_markdown(a[2])
+  xfun::write_utf8(x, a[2])
 })


### PR DESCRIPTION
This is an alternative approach to #1.

Note that it requires `remotes::install_github('rstudio/blogdown')`.